### PR TITLE
表のパフォーマンスとUIを改善

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,9 @@ const sidebarDefine = [
 ];
 
 const sidebar = computed(() =>
-  sidebarDefine.map((sd) => Object.assign(sd, { active: sd.path === route.path }))
+  sidebarDefine.map((sd) =>
+    Object.assign(sd, { active: sd.path === route.path })
+  )
 );
 </script>
 
@@ -50,7 +52,7 @@ const sidebar = computed(() =>
 }
 
 main {
-  margin: 10px;
+  margin: 8px 8px 0 8px;
   width: calc(100% - 8rem - 20px);
 }
 </style>

--- a/src/lib/aviutlModuleRepository.ts
+++ b/src/lib/aviutlModuleRepository.ts
@@ -35,15 +35,19 @@ export class AviUtlModuleRepository {
   }
 
   public search(text: string): AviUtlModule[] {
-    return this.data.filter(
-      (x) =>
-        x.sha256.includes(text.toUpperCase()) ||
-        x.filename.includes(text) ||
-        x.name.includes(text) ||
-        x.author.includes(text) ||
-        x.version.includes(text) ||
-        x.build.includes(text) ||
-        x.url.includes(text)
-    );
+    if (text == "") {
+      return this.data;
+    } else {
+      return this.data.filter(
+        (x) =>
+          x.sha256.includes(text.toUpperCase()) ||
+          x.filename.includes(text) ||
+          x.name.includes(text) ||
+          x.author.includes(text) ||
+          x.version.includes(text) ||
+          x.build.includes(text) ||
+          x.url.includes(text)
+      );
+    }
   }
 }

--- a/src/views/PatchView.vue
+++ b/src/views/PatchView.vue
@@ -2,7 +2,7 @@
 import { PatchDebugInfoParser } from "@/lib/patchDebugInfoParser";
 import type { PatchDebugInfoModule } from "@/lib/patchDebugInfoParser";
 import { AviUtlModuleRepository } from "@/lib/aviutlModuleRepository";
-import { ref, watch } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
 import type { Ref } from "vue";
 
 interface KnownModule {
@@ -19,12 +19,53 @@ interface KnownModule {
 const repo = await AviUtlModuleRepository.getInstance();
 
 const file: Ref<File | undefined> = ref(undefined);
+const dropZoneText = computed(() => {
+  return file.value
+    ? file.value.name
+    : "Drag'n'drop a patch.aul debug info file or";
+});
 
 const tabs = ["known", "unknown"];
 const currentTab = ref(tabs[0]);
 
 const known: Ref<KnownModule[]> = ref([]);
 const unknown: Ref<PatchDebugInfoModule[]> = ref([]);
+const items = computed(() => {
+  return currentTab.value === "known" ? known.value : unknown.value;
+});
+
+const knownCols = ref([
+  { key: "originalFilename", sortable: true },
+  { key: "currentFilename", sortable: true },
+  { key: "name", sortable: true },
+  { key: "version", sortable: true },
+  { key: "build", sortable: true },
+  { key: "author", sortable: true },
+  { key: "url", sortable: true },
+  { key: "sha256", sortable: true },
+]);
+const unknownCols = ref([
+  { key: "filename", sortable: true },
+  { key: "sha256", sortable: true },
+]);
+const columns = computed(() => {
+  return currentTab.value === "known" ? knownCols.value : unknownCols.value;
+});
+
+const tableElem = ref();
+const tableHeight = ref(100);
+
+function updateTableHeight() {
+  const y = tableElem.value.getBoundingClientRect().y;
+  tableHeight.value = window.innerHeight - y;
+}
+
+onMounted(() => {
+  updateTableHeight();
+  window.addEventListener("resize", () => {
+    updateTableHeight();
+  });
+});
 
 watch(file, async (newFile) => {
   if (newFile) {
@@ -58,7 +99,9 @@ watch(file, async (newFile) => {
     v-model="file"
     dropzone
     type="single"
-    drop-zone-text="Drag'n'drop a patch.aul debug info file or"
+    hide-file-list
+    :drop-zone-text="dropZoneText"
+    upload-button-text="Select file"
   />
   <va-tabs v-model="currentTab">
     <template #tabs>
@@ -67,14 +110,17 @@ watch(file, async (newFile) => {
       </va-tab>
     </template>
   </va-tabs>
-  <template v-if="currentTab === 'known'">
-    <va-data-table :items="known" striped>
+  <div ref="tableElem">
+    <va-data-table
+      :items="items"
+      :columns="columns"
+      striped
+      :height="tableHeight"
+      sticky-header
+    >
       <template #cell(url)="{ value }">
         <a :href="value">{{ value }}</a>
       </template>
     </va-data-table>
-  </template>
-  <template v-else-if="currentTab === 'unknown'">
-    <va-data-table :items="unknown" striped></va-data-table>
-  </template>
+  </div>
 </template>

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { ref, computed } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { AviUtlModuleRepository } from "@/lib/aviutlModuleRepository";
-import type { DataTableColumn } from "vuestic-ui";
 
 const repository = await AviUtlModuleRepository.getInstance();
 
@@ -10,19 +9,100 @@ const searchText = ref("");
 const items = computed(() => {
   return repository.search(searchText.value);
 });
+const columns = ref([
+  { key: "filename", sortable: true },
+  { key: "name", sortable: true },
+  { key: "author", sortable: true },
+  { key: "version", sortable: true },
+  { key: "build", sortable: true },
+  { key: "url", sortable: true },
+  { key: "sha256", sortable: true },
+]);
+
+const PER_PAGE = 100;
+const pages = computed(() => {
+  return Math.ceil(items.value.length / PER_PAGE);
+});
+const currentPage = ref(1);
+
+const tableElem = ref();
+const tableHeight = ref(100);
+const paginationElem = ref();
+let pagenationHeight = 36;
+
+function updateTableHeight() {
+  const tableY = tableElem.value.getBoundingClientRect().y;
+  tableHeight.value = window.innerHeight - tableY - pagenationHeight - 8 * 2;
+}
+
+onMounted(() => {
+  pagenationHeight = paginationElem.value.getBoundingClientRect().height;
+
+  updateTableHeight();
+  window.addEventListener("resize", () => {
+    updateTableHeight();
+  });
+});
 
 function onChange(e: Event) {
   const input = e.target as HTMLInputElement;
   searchText.value = input.value;
+  currentPage.value = 1;
+}
+
+function onClear() {
+  searchText.value = "";
+  currentPage.value = 1;
 }
 </script>
 
 <template>
-  <va-input :model-value="searchText" @change="onChange" />
-
-  <va-data-table :items="items" striped>
-    <template #cell(url)="{ value }">
-      <a :href="value">{{ value }}</a>
+  <va-input
+    class="search"
+    :model-value="searchText"
+    clearable
+    @change="onChange"
+    @clear="onClear"
+  >
+    <template #prependInner>
+      <va-icon name="search" />
     </template>
-  </va-data-table>
+  </va-input>
+
+  <div ref="tableElem">
+    <va-data-table
+      :items="items"
+      :columns="columns"
+      striped
+      sticky-header
+      :height="tableHeight"
+      :per-page="PER_PAGE"
+      :current-page="currentPage"
+    >
+      <template #cell(url)="{ value }">
+        <a :href="value">{{ value }}</a>
+      </template>
+    </va-data-table>
+  </div>
+  <div class="table-footer">
+    <div class="pagination-container" ref="paginationElem">
+      <va-pagination v-model="currentPage" :pages="pages" input />
+    </div>
+  </div>
 </template>
+
+<style scoped>
+.search {
+  width: 100%;
+  max-width: 640px;
+}
+
+.table-footer {
+  text-align: center;
+  margin-top: 8px;
+}
+
+.pagination-container {
+  display: inline-block;
+}
+</style>


### PR DESCRIPTION
#3 への対応とそれに関連して表まわりの修正をいくつか行いました。
- searchの表をページネーションさせることで拡大縮小、画面遷移時のパフォーマンスを改善
- 表の横スクロールバーが常に画面内に見えるように修正
- 表のヘッダを見やすくするために固定化
- 表の各列でソートができるように修正
- 検索ボックスを分かりやすくするためにアイコンを表示、削除ボタンを追加、幅を調整